### PR TITLE
Update terminal under Windows

### DIFF
--- a/dso150-110-plot.py
+++ b/dso150-110-plot.py
@@ -195,7 +195,7 @@ if options.data:  # Python 2/3 OK
     if os_name == "Linux":
         f.write('set terminal qt size 1200,675 font "Helvetica,12"'  + "\n") 
     if os_name == "Windows":
-        f.write('set terminal qt size 1200,675'  + "\n") # ratio: 16:9 
+        f.write('set terminal wxt size 1200,675'  + "\n") # ratio: 16:9 
     f.write('set datafile separator ","' + "\n")
     # get data title
     fd = open(fname)


### PR DESCRIPTION
As explained in the wiki:
>GNUplot shows one goody in the lower left corner of the plot. It is the X-Y position of the mouse pointer in
>the coordinate system, in application values, in this case X=Time and Y=Volt. But this does not work on
>Windows 7/10.

The change to wxt-terminal allows for this functionality.